### PR TITLE
"files/site.js: forward key events to embedded examples"

### DIFF
--- a/files/site.js
+++ b/files/site.js
@@ -75,5 +75,26 @@ $(function() {
 		}
 		run.click(onRun);
 	})
+
+	// Current workaround for the issue https://todo.sr.ht/~eliasnaur/gio/415
+	//  where keydown and keyup listeners don't work
+	window.addEventListener('keydown', (e)=> {
+		const frames = document.querySelectorAll('iframe')
+		frames.forEach((frame)=> {
+			const input = frame.contentDocument.querySelector('input')
+			if (input) {
+				input.dispatchEvent(new KeyboardEvent('keydown', {key:e.key}))
+			}
+		})
+	});
+	window.addEventListener('keyup', (e)=> {
+		const frames = document.querySelectorAll('iframe')
+		frames.forEach((frame)=> {
+			const input = frame.contentDocument.querySelector('input')
+			if (input) {
+				input.dispatchEvent(new KeyboardEvent('keyup', {key:e.key}))
+			}
+		})
+	});
 })
 


### PR DESCRIPTION
Fixes: https://todo.sr.ht/~eliasnaur/gio/415
Signed-off-by: Mearaj Bhagad <mearajbhagad@gmail.com>

For some reason most, probably iframes (may be event focus), the gio window inside iframe doesn't receives key events. In this commit, a global key event listener is added and it passes down key events to gio's window embedded inside iframes.